### PR TITLE
Prevent startup crash when a faction JSON file fails to load

### DIFF
--- a/services/warhammer/Warhammer.py
+++ b/services/warhammer/Warhammer.py
@@ -70,11 +70,14 @@ class Warhammer:
         #         counts = counts + Counter(words)
         # print("\',\'".join([x[0] for x in counts.most_common(100)]))
         for f in os.listdir(dataroot + JSON_DATA_PREFIX):
-            with open(dataroot + JSON_DATA_PREFIX + f, "r") as file:
-                wf = WHFaction(json.load(file), xml_units)
-                self.factions[wf.normalized_name] = wf
-                if wf.name:
-                    self.faction_names.append(wf.name)
+            try:
+                with open(dataroot + JSON_DATA_PREFIX + f, "r", encoding="utf-8") as file:
+                    wf = WHFaction(json.load(file), xml_units)
+                    self.factions[wf.normalized_name] = wf
+                    if wf.name:
+                        self.faction_names.append(wf.name)
+            except Exception as e:
+                print(f"Failed to load faction data from {f}: {e}")
         self.compiled_faction_names = []
         self.compiled_faction_names.extend(self.faction_names)
         for k,v in faction_nickname_map.items():


### PR DESCRIPTION
## Summary

- Bot was crashing at startup with `OSError: [Errno 5] Input/output error` in `Warhammer.__init__` when loading faction JSON data, taking the entire bot down
- Wrapped each file load in `try/except` so the bot starts with partial data instead of dying, and logs the failing filename for diagnosis
- Added `encoding='utf-8'` to the `open()` call for cross-platform correctness

## Background

Root cause of the `EIO` is still under investigation (disk space and inodes are both fine at ~17% and ~7% used). The try/except will surface exactly which file is failing once deployed.

## Test plan

- [ ] Deploy and check logs for any `"Failed to load faction data from <filename>: ..."` lines — this will identify the specific file triggering EIO
- [ ] Verify bot starts and responds to commands with whatever faction data successfully loaded