### PR TITLE
Fix host ban ephemeral and Let's Go silent interaction failure

### DIFF
--- a/main.py
+++ b/main.py
@@ -335,11 +335,18 @@ class BapbapView(discord.ui.View):
             await interaction.response.send_message("Need at least 2 players!", ephemeral=True)
             return
 
+        await interaction.response.defer()
+
         self.timeout = None
         for child in self.children:
             child.disabled = True
 
-        assignments = bapbap_hero_list.assign(bapbap_poll.users, bapbap_poll.bans)
+        try:
+            assignments = bapbap_hero_list.assign(bapbap_poll.users, bapbap_poll.bans)
+        except Exception as e:
+            print(f"[bapbap] assign() failed: {e}")
+            await interaction.followup.send("Something went wrong assigning heroes.", ephemeral=True)
+            return
 
         result_embed = discord.Embed(title="BAPBAP — Heroes Assigned!", color=0x9900FF)
         for user, hero in assignments.items():
@@ -347,7 +354,6 @@ class BapbapView(discord.ui.View):
 
         bapbap_poll.end()
         await self.message.edit(embed=result_embed, view=self)
-        await interaction.response.defer()
 
     @discord.ui.button(label="Cancel", row=0, style=discord.ButtonStyle.danger)
     async def cancel_button(self, button, interaction):

--- a/services/bapbap/BapbapPoll.py
+++ b/services/bapbap/BapbapPoll.py
@@ -21,7 +21,6 @@ class BapbapPoll:
         self.active = False
 
     def start(self, init_user):
-        self.users.append(init_user)
         self.owner = init_user
         self.active = True
 


### PR DESCRIPTION
## Summary

- **Host ban ephemeral missing**: `BapbapPoll.start()` was pre-adding the host to `users`, so their first Sign Up click hit the unready branch and never showed the ban selection view. Removed the auto-add — the host now signs up via the button like everyone else.
- **Let's Go silent failure**: `interaction.response.defer()` was called at the very end of `confirm_button`, after `assign()` and `message.edit()`. Any exception before it caused a silent "interaction failed" with nothing logged. Moved `defer()` to immediately after validation so Discord is always acknowledged within 3 seconds, and wrapped `assign()` in try/except to log errors and send a followup.

## Test plan

- [ ] Start `/bapbap` as host → click Sign Up → ban selection ephemeral appears
- [ ] Click Sign Up again to unready, then re-sign-up → ban view appears, no "interaction failed"
- [ ] Have 2+ players sign up, host clicks Let's Go! → heroes assigned, embed updates cleanly
- [ ] Verify no regression: non-host players still get ban ephemeral on sign up

🤖 Generated with [Claude Code](https://claude.com/claude-code)