### PR TITLE
Add silly name substitution to bapbap

### DIFF
--- a/services/bapbap/BapbapHeroList.py
+++ b/services/bapbap/BapbapHeroList.py
@@ -1,11 +1,29 @@
 import json
 import random
+from os.path import exists
 
 
 class BapbapHeroList:
-    def __init__(self, data_path="bapbapHeroData.json"):
+    def __init__(self, data_path="bapbapHeroData.json", namemap_path="services/bapbap/bapbap-namemap.json"):
         with open(data_path, "r") as f:
             self.heroes = json.load(f)
+
+        if exists(namemap_path):
+            with open(namemap_path, "r") as f:
+                self._namemap = json.load(f)
+        else:
+            self._namemap = {}
+
+    def _get_display_name(self, hero):
+        if hero in self._namemap:
+            names = self._namemap[hero]
+            if isinstance(names, str):
+                names = [names, hero]
+            else:
+                names = list(names) + [hero]
+        else:
+            names = [hero]
+        return random.choice(names)
 
     def assign(self, users, bans):
         """Assign one unique hero to each user, respecting bans where possible.
@@ -26,7 +44,7 @@ class BapbapHeroList:
             user_bans = set(bans.get(user.id, []))
             preferred = [h for h in available if h not in user_bans]
             chosen = random.choice(preferred) if preferred else random.choice(available)
-            assignments[user] = chosen
+            assignments[user] = self._get_display_name(chosen)
             available.remove(chosen)
 
         return assignments

--- a/services/bapbap/bapbap-namemap.json
+++ b/services/bapbap/bapbap-namemap.json
@@ -1,0 +1,17 @@
+{
+  "Anna": ["Baja Blast", "Tracer2"],
+  "Froggy": ["Kermit", "Mr. Toad", "Frogger", "Frog"],
+  "Sofia": ["Sword Lady"],
+  "Bishop": ["Teeth", "TEEF"],
+  "Kitsu": ["Foxy Lady", "Bow Lady"],
+  "Chuck": ["CHUCK NORRIS", "Chucky", "DUCK"],
+  "Skinny": ["Bone Man", "Skelly", "Reaper"],
+  "Zook": ["BIG GUN"],
+  "Jiro": ["Legs", "Noodles", "Ramen"],
+  "Teevee": ["Clone Bone", "Copycat"],
+  "Kat": ["Meow", "Catwoman", "Cat Girl"],
+  "Rocky": ["The Rock"],
+  "Sashimi": ["Robot Fish", "Fish Bowl", "Punchy Fish"],
+  "Kiddo": ["Pyro", "Big Nuke", "Napalm Kid", "Fire on Your Sleeve"],
+  "Eve": ["Ice Princess", "Snow Queen", "Frostbite"]
+}


### PR DESCRIPTION
## Summary
- Adds `services/bapbap/bapbap-namemap.json` with silly alternative names for all 15 bapbap heroes
- Updates `BapbapHeroList` to load the namemap and randomly display an alternative name (or the canonical name) on each assignment
- Mirrors the existing `/wiggle` namemap system — same JSON format, same `random.choice()` logic

## Test plan
- [ ] Run `/bapbap`, add players, confirm assignments — verify some heroes show silly names
- [ ] Ban a hero by canonical name, confirm ban still works correctly (substitution happens after selection)
- [ ] Verify heroes display their normal name when the namemap entry isn't hit

🤖 Generated with [Claude Code](https://claude.com/claude-code)