### PR TITLE
Fix Save Bans requiring double-click to register

### DIFF
--- a/main.py
+++ b/main.py
@@ -317,7 +317,9 @@ class BanSelectionView(discord.ui.View):
 
     async def handle_select(self, interaction):
         self.selected_bans = interaction.data.get("values", [])
-        await interaction.response.defer()
+        for opt in self.select.options:
+            opt.default = opt.value in self.selected_bans
+        await interaction.response.edit_message(view=self)
 
     @discord.ui.button(label="Save Bans", row=1, style=discord.ButtonStyle.primary)
     async def save_button(self, button, interaction):


### PR DESCRIPTION
## Summary

- `handle_select` was calling `interaction.response.defer()` after the user changed the ban selection dropdown, leaving an unresolved deferred-update token on the ephemeral message
- When the user then clicked **Save Bans**, Discord saw the pending deferred token and rejected the first button interaction silently — only the second click (after the token expired) went through
- Fixed by replacing `defer()` with `edit_message(view=self)`, which fully resolves the select interaction immediately; also syncs each option's `default` flag so the dropdown visually reflects what the user selected

## Test plan

- [ ] Sign up for a bapbap session, open the ban picker, select heroes, click **Save Bans** — should save on the first click
- [ ] Open the ban picker with pre-existing bans, don't change anything, click **Save Bans** — should still save correctly on first click
- [ ] Open the ban picker, clear all selections, click **Save Bans** — should save "No bans set" on first click

🤖 Generated with [Claude Code](https://claude.com/claude-code)