### PR TITLE
Fix bapbap collage FileNotFoundError caused by silly name used as image path

### DIFF
--- a/main.py
+++ b/main.py
@@ -176,8 +176,8 @@ def bapbap_collage(assignments):
     n = len(items)
     cols = 2
     rows = math.ceil(n / cols)
-    cards = [bapbap_image_with_name(f"services/bapbap/images/{hero}.png", user.display_name, hero)
-             for user, hero in items]
+    cards = [bapbap_image_with_name(f"services/bapbap/images/{real_hero}.png", user.display_name, display_name)
+             for user, (real_hero, display_name) in items]
     single_width = max(c.width for c in cards)
     single_height = max(c.height for c in cards)
     out = Image.new('RGB', (single_width * cols, single_height * rows), color=(47, 49, 54))
@@ -387,8 +387,8 @@ class BapbapView(discord.ui.View):
         bapbap_collage(assignments)
 
         result_embed = discord.Embed(title="BAPBAP — Heroes Assigned!", color=0x9900FF)
-        for user, hero in assignments.items():
-            result_embed.add_field(name=user.display_name, value=hero, inline=True)
+        for user, (real_hero, display_name) in assignments.items():
+            result_embed.add_field(name=user.display_name, value=display_name, inline=True)
         result_embed.set_image(url="attachment://bapbap.jpg")
 
         bapbap_poll.end()

--- a/services/bapbap/BapbapHeroList.py
+++ b/services/bapbap/BapbapHeroList.py
@@ -44,7 +44,7 @@ class BapbapHeroList:
             user_bans = set(bans.get(user.id, []))
             preferred = [h for h in available if h not in user_bans]
             chosen = random.choice(preferred) if preferred else random.choice(available)
-            assignments[user] = self._get_display_name(chosen)
+            assignments[user] = (chosen, self._get_display_name(chosen))
             available.remove(chosen)
 
         return assignments


### PR DESCRIPTION
## Summary
- `BapbapHeroList.assign()` was storing only the silly display name (e.g. `Meow`, `Fish Bowl`) as the assignment value — the real hero name was discarded after being passed to `_get_display_name()`
- `bapbap_collage()` then used that silly name to build the image file path (`services/bapbap/images/Meow.png`), which doesn't exist, causing a silent `FileNotFoundError` when the host clicked **Let's Go!**
- `assign()` now returns `(real_name, display_name)` tuples; callers unpack accordingly

## Changes
- `services/bapbap/BapbapHeroList.py` — `assign()` stores `(chosen, display_name)` tuple instead of just `display_name`
- `main.py` — `bapbap_collage()` unpacks the tuple, using `real_hero` for the image path and `display_name` for the card label
- `main.py` — result embed in `confirm_button` unpacks the tuple and shows `display_name`

## Reviewer notes
Silly names still appear on the collage cards and in the Discord embed — only the image lookup now correctly uses the real hero name.