### PR TITLE
Fix bapbap stuck-active state and UnitView timeout errors

### DIFF
--- a/main.py
+++ b/main.py
@@ -460,10 +460,14 @@ async def wiggle(ctx):
 async def bapbap(ctx, player_count: int = None, bans: bool = True):
     global bapbap_poll
     if not bapbap_poll.active:
+        await ctx.defer()
         bapbap_poll.start(ctx.user, player_count=player_count, bans_enabled=bans)
         view = BapbapView(timeout=get_env_attribute('timeout'))
-        await ctx.respond(embed=bapbap_poll.build_embed(), view=view,
-                          file=discord.File("services/bapbap/images/Logo.webp", filename="logo.webp"))
+        try:
+            await ctx.followup.send(embed=bapbap_poll.build_embed(), view=view,
+                                    file=discord.File("services/bapbap/images/Logo.webp", filename="logo.webp"))
+        except Exception:
+            bapbap_poll.end()
     else:
         await ctx.respond("A BAPBAP session is already active.", ephemeral=True)
 

--- a/services/warhammer/views/UnitView.py
+++ b/services/warhammer/views/UnitView.py
@@ -31,10 +31,13 @@ class UnitView(discord.ui.View):
         self.disable_all_items()
         now = time.time()
         print(f"Button Timeout: {self.created} {self.updated} {now} {now-self.updated} {now-self.created}", )
-        if self.message:
-            await self.message.edit(view=self)
-        else:
-            await self.parent.edit(view=self)
+        try:
+            if self.message:
+                await self.message.edit(view=self)
+            else:
+                await self.parent.edit(view=self)
+        except discord.HTTPException:
+            pass
 
     def get_unit(self):
         return None, self.unit


### PR DESCRIPTION
- Defer bapbap interaction and reset poll on send failure
- Catch expired webhook tokens in UnitView.on_timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)